### PR TITLE
Ajout des validations aux modèles User, Group, Membership et GiftIdea

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,17 @@
 class Group < ApplicationRecord
+  # Relations
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
+
+  # Validations
+  validates :name, presence: true
+
+  # Methods
+  def add_user(user, role = 'member')
+    memberships.create(user: user, role: role)
+  end
+
+  def admin_users
+    memberships.where(role: 'admin').map(&:user)
+  end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,20 @@
 class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :group
+
+  # Constants
+  ROLES = %w[member admin].freeze
+
+  # Validations
+  validates :role, presence: true, inclusion: { in: ROLES }
+  validates :user_id, uniqueness: { scope: :group_id, message: "est déjà membre de ce groupe" }
+
+  # Callbacks
+  before_validation :set_default_role
+
+  private
+
+  def set_default_role
+    self.role ||= 'member'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,22 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
   has_many :memberships, dependent: :destroy
   has_many :groups, through: :memberships
   has_many :created_gift_ideas, class_name: 'GiftIdea', foreign_key: 'created_by_id', dependent: :destroy
   has_many :received_gift_ideas, class_name: 'GiftIdea', foreign_key: 'for_user_id', dependent: :destroy
+
+  # Validations
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  # Methods
+  def common_groups_with(user)
+    groups & user.groups
+  end
+
+  def has_common_group_with?(user)
+    common_groups_with(user).any?
+  end
 end


### PR DESCRIPTION
This pull request introduces several enhancements to the models in the application, focusing on adding validations, constants, methods, and callbacks to ensure data integrity and improve functionality. The primary changes are in the `GiftIdea`, `Group`, `Membership`, and `User` models.

### Enhancements to models:

#### `GiftIdea` model:
* Added constants for statuses and validations for `title`, `link`, `price`, and `status`. Also included a custom validation to check if the creator and receiver have a common group.
* Introduced scopes for different statuses (`proposed`, `buying`, `bought`) and methods to update the status (`mark_as_buying`, `mark_as_bought`).
* Added a `visible_to?` method to determine if a gift idea is visible to a user.
* Implemented callbacks to set a default status before validation.

#### `Group` model:
* Added validation for the presence of the `name` attribute.
* Introduced methods to add a user to a group and to retrieve admin users.

#### `Membership` model:
* Added constants for roles and validations for `role` and uniqueness of `user_id` within the scope of `group_id`.
* Implemented a callback to set a default role before validation.

#### `User` model:
* Added validations for the presence and uniqueness of `name` and `email`, with a proper format for the email.
* Introduced methods to find common groups with another user and to check if there are any common groups.