### PR TITLE
remove the generate_jwt_token from test to use helper

### DIFF
--- a/spec/requests/api/v1/groups_spec.rb
+++ b/spec/requests/api/v1/groups_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe "Api::V1::Groups", type: :request do
   let(:user) { create(:user) }
   let(:headers) { { 'Authorization' => "Bearer #{generate_jwt_token(user)}" } }
 
-  # Helper pour générer un token JWT
-  def generate_jwt_token(user)
-    payload = { user_id: user.id, exp: 24.hours.from_now.to_i }
-    JWT.encode(payload, Rails.application.credentials.secret_key_base)
-  end
-
   describe "GET /api/v1/groups" do
     context "when authenticated" do
       before do

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe "Api::V1::Users", type: :request do
   let(:user) { create(:user) }
   let(:headers) { { 'Authorization' => "Bearer #{generate_jwt_token(user)}" } }
 
-  # Helper pour générer un token JWT
-  def generate_jwt_token(user)
-    payload = { user_id: user.id, exp: 24.hours.from_now.to_i }
-    JWT.encode(payload, Rails.application.credentials.secret_key_base)
-  end
-
   describe "GET /api/v1/users" do
     context "when authenticated" do
       before do


### PR DESCRIPTION
This pull request includes changes to remove a redundant helper method for generating JWT tokens from two test files. The `generate_jwt_token` method has been removed from both `groups_spec.rb` and `users_spec.rb`.

Codebase simplification:

* [`spec/requests/api/v1/groups_spec.rb`](diffhunk://#diff-468a88f13ad06049b4291ff5c0dcecd47959b2e6424100f33122790921cfe32cL8-L13): Removed the `generate_jwt_token` helper method.
* [`spec/requests/api/v1/users_spec.rb`](diffhunk://#diff-8ec6f3422418fdc89fb9da85ce6384e3f40e5a8dd868aec86e1c15c77670dd27L8-L13): Removed the `generate_jwt_token` helper method.