### PR TITLE
Mise à jour du Gemfile.lock et ajout des fixtures pour les tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -148,6 +150,12 @@ GEM
       activesupport (>= 5.0.0)
     jwt (2.10.1)
       base64
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -305,6 +313,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  letter_opener
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5)

--- a/spec/fixtures/invitation_mailer/invitation_created
+++ b/spec/fixtures/invitation_mailer/invitation_created
@@ -1,0 +1,3 @@
+InvitationMailer#invitation_created
+
+Hi, find me in app/views/invitation_mailer/invitation_created


### PR DESCRIPTION
This pull request includes a small change to the `spec/fixtures/invitation_mailer/invitation_created` file. The change adds a comment indicating where the `invitation_created` mailer can be found in the application.

* [`spec/fixtures/invitation_mailer/invitation_created`](diffhunk://#diff-0210694e84fa290172975e61b2aad4513fae5a7cd7329473fc33bbaa0dc65192R1-R3): Added a comment to indicate the location of the `invitation_created` mailer in `app/views/invitation_mailer/invitation_created`.