### PR TITLE
Implement filtering gift ideas by group and multiple statuses

### DIFF
--- a/app/models/gift_idea.rb
+++ b/app/models/gift_idea.rb
@@ -28,6 +28,14 @@ class GiftIdea < ApplicationRecord
   }
   scope :bought_by_user, ->(user) { where(buyer: user) }
 
+  # Nouveau scope pour filtrer par groupe
+  scope :for_group, ->(group_id) {
+    group = Group.find_by(id: group_id)
+    return none unless group
+
+    where(for_user_id: group.users.pluck(:id))
+  }
+
   # Scope principal pour les idées visibles par un utilisateur
   scope :visible_to_user, ->(user) {
     created_by_user(user)


### PR DESCRIPTION
This pull request introduces several enhancements to the `GiftIdea` functionality, including improved filtering capabilities based on status and group, and associated tests to ensure these features work correctly. The most important changes include updates to the `index` action in the `GiftIdeasController`, the addition of a new scope in the `GiftIdea` model, and new tests in the request specs.

### Enhancements to filtering functionality:

* **Controller Updates**:
  * Improved status filtering by allowing multiple statuses to be specified and combined into a single query. (`app/controllers/api/v1/gift_ideas_controller.rb`)
  * Added group-based filtering to ensure gift ideas can be filtered by group membership. (`app/controllers/api/v1/gift_ideas_controller.rb`)

* **Model Updates**:
  * Introduced a new scope `for_group` to filter gift ideas based on group membership. (`app/models/gift_idea.rb`)

### Associated Tests:

* **Request Specs**:
  * Added tests to verify filtering by multiple statuses. (`spec/requests/api/v1/gift_ideas_spec.rb`)
  * Added tests to verify filtering by group ID, including cases for non-existent groups and groups where the user is not a member. (`spec/requests/api/v1/gift_ideas_spec.rb`)