### PR TITLE
Add filter by buyer_id for gift ideas using a reusable scope

### DIFF
--- a/app/controllers/api/v1/gift_ideas_controller.rb
+++ b/app/controllers/api/v1/gift_ideas_controller.rb
@@ -26,11 +26,9 @@ module Api
               when 'proposed'
                 @gift_ideas.proposed
               when 'buying'
-                # Pour 'buying', ne montrer que les cadeaux où l'utilisateur actuel est l'acheteur
-                @gift_ideas.buying.where(buyer_id: current_user.id)
+                @gift_ideas.buying
               when 'bought'
-                # Pour 'bought', ne montrer que les cadeaux où l'utilisateur actuel est l'acheteur
-                @gift_ideas.bought.where(buyer_id: current_user.id)
+                @gift_ideas.bought
               else
                 nil
               end
@@ -58,6 +56,9 @@ module Api
             @gift_ideas = GiftIdea.none
           end
         end
+
+        # Ajouter un filtre pour limiter par acheteur (buyer_id) si demandé
+        @gift_ideas = @gift_ideas.with_buyer(params[:buyer_id]) if params[:buyer_id].present?
 
         # Inclure les associations pour le sérialiseur
         @gift_ideas = @gift_ideas.includes(:for_user, :created_by)

--- a/app/models/gift_idea.rb
+++ b/app/models/gift_idea.rb
@@ -28,6 +28,12 @@ class GiftIdea < ApplicationRecord
   }
   scope :bought_by_user, ->(user) { where(buyer: user) }
 
+  # Scope pour filtrer par acheteur
+  scope :with_buyer, ->(buyer_id) {
+    # Si l'acheteur existe, retourner les cadeaux correspondants
+    buyer_id.present? && User.exists?(buyer_id) ? where(buyer_id: buyer_id) : none
+  }
+
   # Nouveau scope pour filtrer par groupe
   scope :for_group, ->(group_id) {
     group = Group.find_by(id: group_id)


### PR DESCRIPTION
This pull request introduces changes to the `GiftIdeas` feature, focusing on improving the filtering capabilities and updating the associated tests. The most important changes include adding a new scope for filtering by buyer, modifying the controller to utilize this filter, and updating the tests to cover the new functionality.

Enhancements to filtering capabilities:

* [`app/models/gift_idea.rb`](diffhunk://#diff-76bee646a6ea273630785604ad95d0c7bb208cb671f922419c80dca3280c61a6R31-R36): Added a new scope `with_buyer` to filter gift ideas by `buyer_id`. This scope ensures that only valid buyer IDs are considered.

Controller modifications:

* [`app/controllers/api/v1/gift_ideas_controller.rb`](diffhunk://#diff-02483fbdf2a873ffbaeafa23c0c235537bf9a1d8d9ce4ca6e2413e54c1f633b1L29-R31): Updated the `index` action to remove user-specific filtering from the `buying` and `bought` status cases and added a new filter to limit results by `buyer_id` if provided in the parameters. [[1]](diffhunk://#diff-02483fbdf2a873ffbaeafa23c0c235537bf9a1d8d9ce4ca6e2413e54c1f633b1L29-R31) [[2]](diffhunk://#diff-02483fbdf2a873ffbaeafa23c0c235537bf9a1d8d9ce4ca6e2413e54c1f633b1R60-R62)

Test updates:

* [`spec/requests/api/v1/gift_ideas_spec.rb`](diffhunk://#diff-2616bbd94d9e4d93b8cdb3d61b6fe1be7e889fdb073d3c4ba3d8ada8024841c2R154-R183): Added new tests to verify the filtering behavior by `buyer_id`, ensuring that the correct gift ideas are returned based on the provided buyer ID.