### PR TITLE
Add members_count to Group model and include it in API responses

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -28,6 +28,10 @@ class Group < ApplicationRecord
     memberships.where(role: 'admin').count
   end
 
+  def members_count
+    memberships.count
+  end
+
   def create_invitation(created_by, role = 'member')
     invitations.create(created_by: created_by, role: role)
   end


### PR DESCRIPTION
This pull request includes several changes to the `GroupsController` and the `Group` model to include the `members_count` attribute in the JSON responses for various actions. The most important changes include modifications to the `index`, `show`, `create`, and `update` actions in the `GroupsController`, as well as the addition of a `members_count` method in the `Group` model.

Changes to `GroupsController`:

* [`app/controllers/api/v1/groups_controller.rb`](diffhunk://#diff-48db5c15258b04d5f2680708bbb509d41b363767eff3eae14c1fefe43b110a72L12-R14): Modified the `index` action to include `members_count` in the JSON response.
* [`app/controllers/api/v1/groups_controller.rb`](diffhunk://#diff-48db5c15258b04d5f2680708bbb509d41b363767eff3eae14c1fefe43b110a72R24): Modified the `show` action to include `members_count` in the JSON response.
* [`app/controllers/api/v1/groups_controller.rb`](diffhunk://#diff-48db5c15258b04d5f2680708bbb509d41b363767eff3eae14c1fefe43b110a72L35-R39): Modified the `create` action to include `members_count` in the JSON response.
* [`app/controllers/api/v1/groups_controller.rb`](diffhunk://#diff-48db5c15258b04d5f2680708bbb509d41b363767eff3eae14c1fefe43b110a72L44-R48): Modified the `update` action to include `members_count` in the JSON response.

Changes to `Group` model:

* [`app/models/group.rb`](diffhunk://#diff-d60319197e54a8992a066d6243587f4434506f5b924282954fa5f5a8f4ee05e2R31-R34): Added a `members_count` method to calculate the number of members in a group.