### PR TITLE
feat: ajouter paramètre exclude_own_wishlist à l'API gift_ideas

### DIFF
--- a/app/controllers/api/v1/gift_ideas_controller.rb
+++ b/app/controllers/api/v1/gift_ideas_controller.rb
@@ -70,6 +70,11 @@ module Api
         # Ajouter un filtre pour limiter par acheteur (buyer_id) si demandé
         @gift_ideas = @gift_ideas.with_buyer(params[:buyer_id]) if params[:buyer_id].present?
 
+        # Exclure les idées cadeaux dont l'utilisateur courant est destinataire si demandé
+        if params[:exclude_own_wishlist].present? && params[:exclude_own_wishlist] == 'true'
+          @gift_ideas = @gift_ideas.not_for_user(current_user)
+        end
+
         # Inclure les associations pour le sérialiseur
         @gift_ideas = @gift_ideas.includes(:recipients, :created_by)
 


### PR DESCRIPTION
This pull request includes an enhancement to the filtering logic in the `index` method of the `GiftIdeasController`. The most important change is the addition of a new filter that allows users to exclude gift ideas from their own wishlist.

Enhancements to filtering logic:

* [`app/controllers/api/v1/gift_ideas_controller.rb`](diffhunk://#diff-02483fbdf2a873ffbaeafa23c0c235537bf9a1d8d9ce4ca6e2413e54c1f633b1R73-R77): Added a condition to exclude gift ideas where the current user is the recipient if the `exclude_own_wishlist` parameter is set to 'true'.