### PR TITLE
fix: handle empty groups in API and fix user sharing functionality

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -8,9 +8,21 @@ module Api
 
       # GET /api/v1/groups
       def index
-        @groups = current_user.groups
+        @groups = current_user.groups || []
+
+        # Utiliser to_json et éviter l'utilisation du serializer qui génère l'erreur
+        if @groups.empty?
+          render json: { groups: [] }, adapter: nil
+          return
+        end
+
         render json: @groups.map { |group|
-          group.as_json(only: [:id, :name, :description]).merge(members_count: group.members_count)
+          # S'assurer que group est valide avant d'appeler members_count
+          if group.respond_to?(:members_count)
+            group.as_json(only: [:id, :name, :description]).merge(members_count: group.members_count)
+          else
+            group.as_json(only: [:id, :name, :description]).merge(members_count: 0)
+          end
         }
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,13 +13,31 @@ module Api
 
       # GET /api/v1/users/:id
       def show
-        render json: { user: @user.as_json(only: [:id, :name, :email]) }
+        render json: { user: @user.as_json(except: [:encrypted_password, :reset_password_token, :reset_password_sent_at]) }
+      end
+
+      # GET /api/v1/users/shared_users
+      def shared_users
+        # Cette action ne nécessite pas de paramètres car elle utilise current_user
+        user_ids = current_user.common_groups_with_users_ids
+        render json: { user_ids: user_ids }
       end
 
       # PUT /api/v1/users/:id
       def update
-        if @user.update(user_params)
-          render json: { user: @user.as_json(only: [:id, :name, :email]) }
+        # Si le mot de passe est modifié, vérifier l'ancien mot de passe
+        if user_params[:password].present?
+          unless @user.valid_password?(user_params[:current_password])
+            render json: { errors: ['Current password is incorrect'] }, status: :unprocessable_entity
+            return
+          end
+        end
+
+        # Filtrer les paramètres pour exclure current_password qui n'est pas un attribut du modèle
+        update_params = user_params.except(:current_password)
+
+        if @user.update(update_params)
+          render json: { user: @user.as_json(except: [:encrypted_password, :reset_password_token, :reset_password_sent_at]) }
         else
           render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
         end
@@ -48,7 +66,20 @@ module Api
       end
 
       def user_params
-        params.require(:user).permit(:name, :email)
+        params.require(:user).permit(
+          :name,
+          :email,
+          :password,
+          :password_confirmation,
+          :current_password,
+          :birthday,
+          :phone_number,
+          :address,
+          :city,
+          :state,
+          :zip_code,
+          :country
+        )
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,12 @@ class User < ApplicationRecord
 
   # Retourne les IDs des utilisateurs avec lesquels l'utilisateur partage un groupe
   def common_groups_with_users_ids
+    # Retourner un tableau vide si l'utilisateur n'a pas de groupes
+    group_ids = self.groups.pluck(:id)
+    return [] if group_ids.empty?
+
     User.joins(:memberships)
-        .where(memberships: { group_id: self.groups.pluck(:id) })
+        .where(memberships: { group_id: group_ids })
         .where.not(id: self.id)
         .distinct
         .pluck(:id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,11 @@ Rails.application.routes.draw do
                    registration: 'signup'
                  }
 
-      resources :users, only: [:index, :show, :update, :destroy]
+      resources :users, only: [:index, :show, :update, :destroy] do
+        collection do
+          get 'shared_users'
+        end
+      end
 
       resources :groups do
         resources :memberships


### PR DESCRIPTION
This pull request includes several important updates to the user and group management features in the API. The changes enhance the handling of user data, improve error handling, and add new routes and actions.

### User Management Enhancements:
* [`app/controllers/api/v1/users_controller.rb`](diffhunk://#diff-ef20d40ddd2dd2a254d26fd4c59655cbed6b541c5f908b81125d09848c1dfeb6L16-R40): Modified the `show` action to exclude sensitive attributes from the JSON response and added a new `shared_users` action to list users with common group memberships. Updated the `update` action to verify the current password when changing the password and to exclude the `current_password` parameter from the update.
* [`app/controllers/api/v1/users_controller.rb`](diffhunk://#diff-ef20d40ddd2dd2a254d26fd4c59655cbed6b541c5f908b81125d09848c1dfeb6L51-R82): Expanded the permitted parameters in the `user_params` method to include additional user attributes such as `password`, `birthday`, and `address`.

### Group Management Enhancements:
* [`app/controllers/api/v1/groups_controller.rb`](diffhunk://#diff-48db5c15258b04d5f2680708bbb509d41b363767eff3eae14c1fefe43b110a72L11-R25): Updated the `index` action to handle cases where the user has no groups and to ensure the `members_count` method is called only on valid group objects.

### Model Enhancements:
* [`app/models/user.rb`](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR32-R37): Improved the `common_groups_with_users_ids` method to return an empty array if the user has no groups, optimizing the query for users with common group memberships.

### Routing Enhancements:
* [`config/routes.rb`](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5L26-R30): Added a new route for the `shared_users` action in the `users` resource.