### PR TITLE
fix: remove user association from invitations and update mailer accor…

### DIFF
--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -131,16 +131,12 @@ module Api
       end
 
       def notify_admins_about_new_member(invitation, user)
-        # Mettre à jour l'invitation avec l'utilisateur qui l'a acceptée
-        invitation.user = user
-        invitation.save if invitation.changed?
-
         # Envoyer un email à l'admin qui a créé l'invitation
         # Utiliser deliver_now en environnement de test pour que les tests puissent vérifier l'envoi
         if Rails.env.test?
-          InvitationMailer.invitation_accepted(invitation).deliver_now
+          InvitationMailer.invitation_accepted(invitation, user).deliver_now
         else
-          InvitationMailer.invitation_accepted(invitation).deliver_later
+          InvitationMailer.invitation_accepted(invitation, user).deliver_later
         end
       end
     end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -31,9 +31,9 @@ class InvitationMailer < ApplicationMailer
   end
 
   # Envoie un email lorsqu'une invitation est acceptée
-  def invitation_accepted(invitation)
+  def invitation_accepted(invitation, user)
     @invitation = invitation
-    @user = invitation.user
+    @user = user
     @group = invitation.group
 
     # Obtenir l'administrateur du groupe (le premier admin ou le créateur de l'invitation)
@@ -42,9 +42,11 @@ class InvitationMailer < ApplicationMailer
 
     # Determine preferred locale based on admin's locale
     locale = @admin.locale
+    Rails.logger.info("Sending invitation accepted email with locale: #{locale}")
 
     # Validate locale
     unless I18n.available_locales.map(&:to_s).include?(locale.to_s)
+      Rails.logger.info("Invalid locale #{locale}, defaulting to #{I18n.default_locale}")
       locale = I18n.default_locale
     end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,6 @@ class Invitation < ApplicationRecord
   # Associations
   belongs_to :group
   belongs_to :created_by, class_name: 'User'
-  belongs_to :user, class_name: 'User', optional: true
 
   # Constants
   ROLES = %w[member admin].freeze

--- a/db/migrate/20250320073626_remove_user_from_invitations.rb
+++ b/db/migrate/20250320073626_remove_user_from_invitations.rb
@@ -1,0 +1,5 @@
+class RemoveUserFromInvitations < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :invitations, :user, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_19_182034) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_20_073626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,11 +53,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_19_182034) do
     t.string "role", default: "member", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
     t.index ["created_by_id"], name: "index_invitations_on_created_by_id"
     t.index ["group_id"], name: "index_invitations_on_group_id"
     t.index ["token"], name: "index_invitations_on_token", unique: true
-    t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 
   create_table "jwt_denylists", force: :cascade do |t|
@@ -105,7 +103,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_19_182034) do
   add_foreign_key "gift_recipients", "gift_ideas"
   add_foreign_key "gift_recipients", "users"
   add_foreign_key "invitations", "groups"
-  add_foreign_key "invitations", "users"
   add_foreign_key "invitations", "users", column: "created_by_id"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"


### PR DESCRIPTION
This pull request includes several changes to the invitation system in the application. The main focus is on removing the association between `Invitation` and `User` and updating the email notification system accordingly.

Changes to invitation system:

* [`app/controllers/api/v1/invitations_controller.rb`](diffhunk://#diff-283a9949d5ddad675b3a1cdc419f7501a15c7284d7c848ab21edb314952a4a26L134-R139): Updated the `notify_admins_about_new_member` method to remove the association between `Invitation` and `User` and to pass the `user` parameter directly to the `InvitationMailer` methods.

* [`app/mailers/invitation_mailer.rb`](diffhunk://#diff-7c26fdfd27e8a00c6e6ffda69df8a727e9742efad6a734f99a6fbaa00bb12e3dL34-R36): Modified the `invitation_accepted` method to accept a `user` parameter instead of relying on the `Invitation` model's `user` attribute. Added logging for locale validation. [[1]](diffhunk://#diff-7c26fdfd27e8a00c6e6ffda69df8a727e9742efad6a734f99a6fbaa00bb12e3dL34-R36) [[2]](diffhunk://#diff-7c26fdfd27e8a00c6e6ffda69df8a727e9742efad6a734f99a6fbaa00bb12e3dR45-R49)

Database schema updates:

* [`app/models/invitation.rb`](diffhunk://#diff-c899291de1875b0c2483c0f132ed4503e6c33be63148d6e5d1f4235bfeb1c331L5): Removed the `belongs_to :user` association from the `Invitation` model.

* [`db/migrate/20250320073626_remove_user_from_invitations.rb`](diffhunk://#diff-36955c2302d34f0822514fb542c99419c3b21a043d62435ba6d9f0b07eaf200dR1-R5): Added a migration to remove the `user` reference from the `invitations` table.

* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13): Updated the schema to reflect the removal of the `user_id` column and the associated foreign key from the `invitations` table. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L56-L60) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L108)…dingly