### PR TITLE
Feature: Mise en place de l'API newsletter avec Brevo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'active_model_serializers', '~> 0.10.13'
 gem 'nokogiri', '~> 1.15'
 gem 'open_uri_redirections', '~> 0.2.1' # Support des redirections pour open-uri
 
+# Gem pour l'intégration avec Brevo (anciennement Sendinblue)
+gem 'brevo'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    brevo (3.0.0)
+      addressable (~> 2.3, >= 2.3.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -139,11 +143,14 @@ GEM
       logger
       zeitwerk (~> 2.6)
     erubi (1.13.1)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    ffi (1.17.1-arm64-darwin)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -159,6 +166,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.10.2)
     jsonapi-renderer (0.2.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
@@ -297,6 +305,8 @@ GEM
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
@@ -325,6 +335,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.13)
   bootsnap
+  brevo
   capybara
   debug
   devise

--- a/app/controllers/api/v1/newsletter_subscriptions_controller.rb
+++ b/app/controllers/api/v1/newsletter_subscriptions_controller.rb
@@ -1,0 +1,75 @@
+module Api
+  module V1
+    class NewsletterSubscriptionsController < BaseController
+      skip_before_action :authenticate_user!
+
+      def create
+        subscription_params = newsletter_subscription_params
+        email = subscription_params[:email]
+        list_id = subscription_params[:list_id] || ENV['BREVO_LIST_ID']
+        redirect_url = subscription_params[:redirect_url] || ENV['FRONTEND_URL']
+
+        unless email.present? && valid_email?(email)
+          return render json: { error: I18n.t('newsletter.errors.invalid_email') }, status: :unprocessable_entity
+        end
+
+        begin
+          # Utiliser le service pour gérer l'abonnement
+          response = BrevoService.subscribe_contact(email, list_id, redirect_url)
+
+          if response[:success]
+            render json: { message: I18n.t('newsletter.subscription_success') }, status: :ok
+          else
+            render json: { error: response[:error] || I18n.t('newsletter.errors.generic') }, status: :unprocessable_entity
+          end
+        rescue => e
+          Rails.logger.error("Newsletter subscription error: #{e.message}")
+          render json: { error: I18n.t('newsletter.errors.generic') }, status: :internal_server_error
+        end
+      end
+
+      # Ajouter une action pour désabonner un contact
+      def destroy
+        email = params[:email]
+
+        unless email.present? && valid_email?(email)
+          return render json: { error: I18n.t('newsletter.errors.invalid_email') }, status: :unprocessable_entity
+        end
+
+        begin
+          # Utiliser le service pour gérer le désabonnement
+          response = BrevoService.unsubscribe_contact(email, params[:list_id])
+
+          if response[:success]
+            render json: { message: I18n.t('newsletter.unsubscription_success', default: 'Successfully unsubscribed from newsletter') }, status: :ok
+          else
+            render json: { error: response[:error] || I18n.t('newsletter.errors.generic') }, status: :unprocessable_entity
+          end
+        rescue => e
+          Rails.logger.error("Newsletter unsubscription error: #{e.message}")
+          render json: { error: I18n.t('newsletter.errors.generic') }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def newsletter_subscription_params
+        # Gestion des différentes structures de paramètres possibles
+        if params[:newsletter_subscription].present? && params[:newsletter_subscription][:newsletter].present?
+          # Double imbrication: { newsletter_subscription: { newsletter: { email: ... } } }
+          params[:newsletter_subscription].require(:newsletter).permit(:email, :list_id, :redirect_url)
+        elsif params[:newsletter].present?
+          # Imbrication simple: { newsletter: { email: ... } }
+          params.require(:newsletter).permit(:email, :list_id, :redirect_url)
+        else
+          # Pas d'imbrication: { email: ... }
+          params.permit(:email, :list_id, :redirect_url)
+        end
+      end
+
+      def valid_email?(email)
+        email =~ URI::MailTo::EMAIL_REGEXP
+      end
+    end
+  end
+end

--- a/app/services/brevo_service.rb
+++ b/app/services/brevo_service.rb
@@ -1,0 +1,69 @@
+# Service pour gérer les interactions avec l'API Brevo
+class BrevoService
+  class << self
+    # Abonne un email à une liste Brevo
+    # @param email [String] l'email à abonner
+    # @param list_id [String] l'ID de la liste Brevo (optionnel)
+    # @param redirect_url [String] l'URL de redirection (non utilisé, conservé pour compatibilité d'API)
+    # @return [Hash] résultat de l'opération avec :success et éventuellement :error
+    def subscribe_contact(email, list_id = nil, redirect_url = nil)
+      list_id ||= ENV['BREVO_LIST_ID']
+
+      begin
+        # Créer un client pour l'API Contacts
+        api_instance = Brevo::ContactsApi.new
+
+        # Préparer les données du contact
+        create_contact = Brevo::CreateContact.new
+        create_contact.email = email
+        create_contact.list_ids = [list_id.to_i]
+        create_contact.update_enabled = true
+        # Note: redirect_url n'est pas supporté par l'API Brevo et a été supprimé
+
+        # Ajouter le contact à Brevo
+        api_instance.create_contact(create_contact)
+
+        { success: true }
+      rescue Brevo::ApiError => e
+        error_json = JSON.parse(e.response_body) rescue { message: e.message }
+        Rails.logger.error("Brevo API error: #{error_json}")
+        { success: false, error: error_json['message'] || e.message }
+      rescue => e
+        Rails.logger.error("Newsletter subscription error: #{e.message}")
+        { success: false, error: e.message }
+      end
+    end
+
+    # Désabonne un email d'une liste Brevo
+    # @param email [String] l'email à désabonner
+    # @param list_id [String] l'ID de la liste Brevo (optionnel)
+    # @return [Hash] résultat de l'opération avec :success et éventuellement :error
+    def unsubscribe_contact(email, list_id = nil)
+      list_id ||= ENV['BREVO_LIST_ID']
+
+      begin
+        # Créer un client pour l'API Contacts
+        api_instance = Brevo::ContactsApi.new
+
+        # Rechercher le contact par email
+        contacts = api_instance.get_contacts_from_list(list_id.to_i, email: email)
+
+        if contacts.contacts.empty?
+          return { success: false, error: "Email not found in list" }
+        end
+
+        # Désabonner le contact de la liste
+        api_instance.remove_contact_from_list(list_id.to_i, contacts.contacts.first.id)
+
+        { success: true }
+      rescue Brevo::ApiError => e
+        error_json = JSON.parse(e.response_body) rescue { message: e.message }
+        Rails.logger.error("Brevo API error: #{error_json}")
+        { success: false, error: error_json['message'] || e.message }
+      rescue => e
+        Rails.logger.error("Newsletter unsubscription error: #{e.message}")
+        { success: false, error: e.message }
+      end
+    end
+  end
+end

--- a/config/initializers/brevo.rb
+++ b/config/initializers/brevo.rb
@@ -1,0 +1,13 @@
+# Configuration de l'API Brevo
+# Documentation: https://github.com/getbrevo/brevo-ruby
+
+Brevo.configure do |config|
+  # API key disponible dans l'interface Brevo sous "SMTP & API" > "API Keys"
+  config.api_key['api-key'] = ENV['BREVO_API_KEY']
+
+  # Configuration optionnelle du timeout
+  config.timeout = 30 # secondes
+
+  # Configuration du mode debug en développement
+  config.debugging = Rails.env.development?
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,9 +32,16 @@ en:
   mailers:
     devise:
       reset_password_instructions:
-        subject: "Reset Password Instructions"
+        subject: "Reset password instructions"
     invitation:
       created:
         subject: "Invitation to join %{group} on Gifters"
       accepted:
         subject: "%{user} has joined your group on Gifters"
+
+  newsletter:
+    subscription_success: "You are now subscribed to our newsletter!"
+    unsubscription_success: "You have been successfully unsubscribed from our newsletter."
+    errors:
+      invalid_email: "Please provide a valid email address"
+      generic: "An error occurred while subscribing to the newsletter"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,3 +8,10 @@ fr:
         subject: "Invitation à rejoindre %{group} sur Gifters"
       accepted:
         subject: "%{user} a rejoint votre groupe sur Gifters"
+
+  newsletter:
+    subscription_success: "Vous êtes désormais abonné à notre newsletter !"
+    unsubscription_success: "Vous avez été désabonné de notre newsletter avec succès."
+    errors:
+      invalid_email: "Veuillez fournir une adresse email valide"
+      generic: "Une erreur est survenue lors de l'abonnement à la newsletter"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,12 @@ Rails.application.routes.draw do
 
       # Route pour envoyer un message via le formulaire de contact
       post 'contact', to: 'contacts#create'
+
+      # Route pour s'abonner à la newsletter via Brevo
+      post 'newsletter/subscribe', to: 'newsletter_subscriptions#create'
+
+      # Route pour se désabonner de la newsletter
+      delete 'newsletter/unsubscribe', to: 'newsletter_subscriptions#destroy'
     end
   end
 


### PR DESCRIPTION
This pull request introduces the integration of the Brevo service (formerly Sendinblue) for managing newsletter subscriptions and unsubscriptions. The changes include adding new dependencies, creating a controller for handling subscription requests, and setting up the Brevo service.

### Integration with Brevo:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR62-R64): Added the `brevo` gem for integration with the Brevo API.
* [`config/initializers/brevo.rb`](diffhunk://#diff-e172aab733293f931cdee0d1e55d1e29e8fcd938ce16f730a34a74cc4f0be2aaR1-R13): Configured the Brevo API with the necessary API key and settings.

### Newsletter Subscriptions Controller:

* [`app/controllers/api/v1/newsletter_subscriptions_controller.rb`](diffhunk://#diff-32cac31a5e24dddc645dc7215b81e899050a978088d0f9d24674931acc21da00R1-R75): Created a new controller to handle subscription and unsubscription requests using the Brevo service.
* [`config/routes.rb`](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R63-R68): Added routes for subscribing and unsubscribing from the newsletter.

### Brevo Service:

* [`app/services/brevo_service.rb`](diffhunk://#diff-44da89f1dbcd1483c1dbe4e19a122195a6c6e7fb34b2cc0f741f645412d386deR1-R69): Implemented the BrevoService class to manage interactions with the Brevo API for subscribing and unsubscribing contacts.

### Localization:

* [`config/locales/en.yml`](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7L35-R47): Added English translations for newsletter subscription and unsubscription messages.
* [`config/locales/fr.yml`](diffhunk://#diff-2c5ab6165f7efe573a84107e0e51102ad47cefb0c65629759d7458eee14326e7R11-R17): Added French translations for newsletter subscription and unsubscription messages.